### PR TITLE
Added a key for name

### DIFF
--- a/example_datapack/data/mynamespace/filament/block/amethyst/amethyst_bricks.json
+++ b/example_datapack/data/mynamespace/filament/block/amethyst/amethyst_bricks.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_bricks",
-  "name": { "en_us": "§dAmethyst Bricks" },
+  "displayName": { "en_us": "§dAmethyst Bricks" },
   "blockModelType": "full_block",
   "blockResource": {
     "models": {

--- a/example_datapack/data/mynamespace/filament/block/amethyst/amethyst_bricks.json
+++ b/example_datapack/data/mynamespace/filament/block/amethyst/amethyst_bricks.json
@@ -1,5 +1,6 @@
 {
   "id": "mynamespace:amethyst_bricks",
+  "name": "§dAmethyst Bricks",
   "blockModelType": "full_block",
   "blockResource": {
     "models": {

--- a/example_datapack/data/mynamespace/filament/block/amethyst/amethyst_bricks.json
+++ b/example_datapack/data/mynamespace/filament/block/amethyst/amethyst_bricks.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_bricks",
-  "name": "§dAmethyst Bricks",
+  "name": { "en_us": "§dAmethyst Bricks" },
   "blockModelType": "full_block",
   "blockResource": {
     "models": {

--- a/example_datapack/data/mynamespace/filament/decoration/umbrella/striped_beach_umbrella_top.json
+++ b/example_datapack/data/mynamespace/filament/decoration/umbrella/striped_beach_umbrella_top.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:striped_beach_umbrella_top",
-  "name": "§aStriped Beach Umbrella Top",
+  "name": { "en_us": "§aStriped Beach Umbrella Top" },
   "model": "minecraft:custom/furniture/umbrella/striped_beach_umbrella_top",
   "vanillaItem": "minecraft:leather_horse_armor",
   "properties": {

--- a/example_datapack/data/mynamespace/filament/decoration/umbrella/striped_beach_umbrella_top.json
+++ b/example_datapack/data/mynamespace/filament/decoration/umbrella/striped_beach_umbrella_top.json
@@ -1,5 +1,6 @@
 {
   "id": "mynamespace:striped_beach_umbrella_top",
+  "name": "§aStriped Beach Umbrella Top",
   "model": "minecraft:custom/furniture/umbrella/striped_beach_umbrella_top",
   "vanillaItem": "minecraft:leather_horse_armor",
   "properties": {

--- a/example_datapack/data/mynamespace/filament/decoration/umbrella/striped_beach_umbrella_top.json
+++ b/example_datapack/data/mynamespace/filament/decoration/umbrella/striped_beach_umbrella_top.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:striped_beach_umbrella_top",
-  "name": { "en_us": "§aStriped Beach Umbrella Top" },
+  "displayName": { "en_us": "§aStriped Beach Umbrella Top" },
   "model": "minecraft:custom/furniture/umbrella/striped_beach_umbrella_top",
   "vanillaItem": "minecraft:leather_horse_armor",
   "properties": {

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_boots.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_boots.json
@@ -1,5 +1,6 @@
 {
   "id": "mynamespace:amethyst_boots",
+  "name": "§dAmethyst Boots",
   "vanillaItem": "minecraft:chainmail_boots",
   "itemResource":  {
     "models": {

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_boots.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_boots.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_boots",
-  "name": { "en_us": "§dAmethyst Boots" },
+  "displayName": { "en_us": "§dAmethyst Boots" },
   "vanillaItem": "minecraft:chainmail_boots",
   "itemResource": {
     "models": {

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_boots.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_boots.json
@@ -1,8 +1,8 @@
 {
   "id": "mynamespace:amethyst_boots",
-  "name": "§dAmethyst Boots",
+  "name": { "en_us": "§dAmethyst Boots" },
   "vanillaItem": "minecraft:chainmail_boots",
-  "itemResource":  {
+  "itemResource": {
     "models": {
       "default": "minecraft:custom/traps/allay_bottle"
     }

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_chestplate.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_chestplate.json
@@ -1,5 +1,6 @@
 {
   "id": "mynamespace:amethyst_chestplate",
+  "name": "§dAmethyst Chestplate",
   "vanillaItem": "minecraft:leather_chestplate",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_chestplate.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_chestplate.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_chestplate",
-  "name": "§dAmethyst Chestplate",
+  "name": { "en_us": "§dAmethyst Chestplate" },
   "vanillaItem": "minecraft:leather_chestplate",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_chestplate.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_chestplate.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_chestplate",
-  "name": { "en_us": "§dAmethyst Chestplate" },
+  "displayName": { "en_us": "§dAmethyst Chestplate" },
   "vanillaItem": "minecraft:leather_chestplate",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_helmet.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_helmet.json
@@ -1,5 +1,6 @@
 {
   "id": "mynamespace:amethyst_helmet",
+  "name": "§dAmethyst Helmet",
   "vanillaItem": "minecraft:leather_helmet",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_helmet.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_helmet.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_helmet",
-  "name": { "en_us": "§dAmethyst Helmet" },
+  "displayName": { "en_us": "§dAmethyst Helmet" },
   "vanillaItem": "minecraft:leather_helmet",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_helmet.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_helmet.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_helmet",
-  "name": "§dAmethyst Helmet",
+  "name": { "en_us": "§dAmethyst Helmet" },
   "vanillaItem": "minecraft:leather_helmet",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_leggings.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_leggings.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_leggings",
-  "name": "§dAmethyst Leggings",
+  "name": { "en_us": "§dAmethyst Leggings" },
   "vanillaItem": "minecraft:leather_leggings",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_leggings.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_leggings.json
@@ -1,5 +1,6 @@
 {
   "id": "mynamespace:amethyst_leggings",
+  "name": "§dAmethyst Leggings",
   "vanillaItem": "minecraft:leather_leggings",
   "properties": {
     "durability": 10,

--- a/example_datapack/data/mynamespace/filament/item/armor/amethyst_leggings.json
+++ b/example_datapack/data/mynamespace/filament/item/armor/amethyst_leggings.json
@@ -1,6 +1,6 @@
 {
   "id": "mynamespace:amethyst_leggings",
-  "name": { "en_us": "§dAmethyst Leggings" },
+  "displayName": { "en_us": "§dAmethyst Leggings" },
   "vanillaItem": "minecraft:leather_leggings",
   "properties": {
     "durability": 10,

--- a/src/main/java/de/tomalbrc/filament/data/BlockData.java
+++ b/src/main/java/de/tomalbrc/filament/data/BlockData.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 
 public record BlockData(
-        @Nullable String name,
+        @Nullable Map<String, String> name,
         @NotNull ResourceLocation id,
         @Nullable Item vanillaItem,
         @NotNull BlockResource blockResource,

--- a/src/main/java/de/tomalbrc/filament/data/BlockData.java
+++ b/src/main/java/de/tomalbrc/filament/data/BlockData.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 
 public record BlockData(
-        @Nullable Map<String, String> name,
+        @Nullable Map<String, String> displayName,
         @NotNull ResourceLocation id,
         @Nullable Item vanillaItem,
         @NotNull BlockResource blockResource,

--- a/src/main/java/de/tomalbrc/filament/data/BlockData.java
+++ b/src/main/java/de/tomalbrc/filament/data/BlockData.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 
 public record BlockData(
+        @Nullable String name,
         @NotNull ResourceLocation id,
         @Nullable Item vanillaItem,
         @NotNull BlockResource blockResource,

--- a/src/main/java/de/tomalbrc/filament/data/DecorationData.java
+++ b/src/main/java/de/tomalbrc/filament/data/DecorationData.java
@@ -18,10 +18,11 @@ import org.joml.Vector2f;
 import org.joml.Vector3f;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public record DecorationData(
-        @Nullable String name,
+        @Nullable Map<String, String> name,
         @NotNull ResourceLocation id,
         @NotNull ResourceLocation model,
 

--- a/src/main/java/de/tomalbrc/filament/data/DecorationData.java
+++ b/src/main/java/de/tomalbrc/filament/data/DecorationData.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record DecorationData(
+        @Nullable String name,
         @NotNull ResourceLocation id,
         @NotNull ResourceLocation model,
 

--- a/src/main/java/de/tomalbrc/filament/data/DecorationData.java
+++ b/src/main/java/de/tomalbrc/filament/data/DecorationData.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public record DecorationData(
-        @Nullable Map<String, String> name,
+        @Nullable Map<String, String> displayName,
         @NotNull ResourceLocation id,
         @NotNull ResourceLocation model,
 

--- a/src/main/java/de/tomalbrc/filament/data/ItemData.java
+++ b/src/main/java/de/tomalbrc/filament/data/ItemData.java
@@ -14,9 +14,11 @@ import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
+
 @SuppressWarnings("unused")
 public record ItemData(
-        @Nullable String name,
+        @Nullable Map<String, String> name,
         @NotNull ResourceLocation id,
         @Nullable Item vanillaItem,
         @Nullable ItemResource itemResource,

--- a/src/main/java/de/tomalbrc/filament/data/ItemData.java
+++ b/src/main/java/de/tomalbrc/filament/data/ItemData.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 @SuppressWarnings("unused")
 public record ItemData(
-        @Nullable Map<String, String> name,
+        @Nullable Map<String, String> displayName,
         @NotNull ResourceLocation id,
         @Nullable Item vanillaItem,
         @Nullable ItemResource itemResource,

--- a/src/main/java/de/tomalbrc/filament/data/ItemData.java
+++ b/src/main/java/de/tomalbrc/filament/data/ItemData.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("unused")
 public record ItemData(
+        @Nullable String name,
         @NotNull ResourceLocation id,
         @Nullable Item vanillaItem,
         @Nullable ItemResource itemResource,

--- a/src/main/java/de/tomalbrc/filament/registry/BlockRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/BlockRegistry.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BlockRegistry {
-    private static final Map<ResourceLocation, String> blockNames = new HashMap<>();
+    private static final Map<ResourceLocation, Map<String, String>> blockNames = new HashMap<>();
     public static int REGISTERED_BLOCKS = 0;
 
     public static void register(InputStream inputStream) throws IOException {
@@ -62,7 +62,7 @@ public class BlockRegistry {
         REGISTERED_BLOCKS++;
     }
 
-    public static void registerBlock(@Nullable String name, ResourceLocation identifier, Block block) {
+    public static void registerBlock(@Nullable Map<String, String> name, ResourceLocation identifier, Block block) {
         Registry.register(BuiltInRegistries.BLOCK, identifier, block);
         if (name != null) {
             blockNames.putIfAbsent(identifier, name);

--- a/src/main/java/de/tomalbrc/filament/registry/BlockRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/BlockRegistry.java
@@ -54,7 +54,7 @@ public class BlockRegistry {
         BehaviourUtil.postInitItem(item, item, data.behaviourConfig());
         BehaviourUtil.postInitBlock(item, customBlock, customBlock, data.behaviourConfig());
 
-        BlockRegistry.registerBlock(data.name(), data.id(), customBlock);
+        BlockRegistry.registerBlock(data.displayName(), data.id(), customBlock);
         ItemRegistry.registerItem(data.id(), item, data.itemGroup() != null ? data.itemGroup() : Constants.BLOCK_GROUP_ID);
 
         customBlock.postRegister();

--- a/src/main/java/de/tomalbrc/filament/registry/DecorationRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/DecorationRegistry.java
@@ -68,7 +68,7 @@ public class DecorationRegistry {
         }
 
         decorationBlocks.put(data.id(), block);
-        BlockRegistry.registerBlock(data.name(), data.id(), block);
+        BlockRegistry.registerBlock(data.displayName(), data.id(), block);
 
         Item.Properties properties = data.properties().toItemProperties();
 

--- a/src/main/java/de/tomalbrc/filament/registry/DecorationRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/DecorationRegistry.java
@@ -37,13 +37,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class DecorationRegistry {
-    public static int REGISTERED_BLOCK_ENTITIES = 0;
-    public static int REGISTERED_DECORATIONS = 0;
-
     private static final Object2ObjectOpenHashMap<ResourceLocation, DecorationData> decorations = new Object2ObjectOpenHashMap<>();
-
     private static final Object2ObjectOpenHashMap<ResourceLocation, Block> decorationBlocks = new Object2ObjectOpenHashMap<>();
     private static final Object2ObjectOpenHashMap<Block, BlockEntityType<DecorationBlockEntity>> decorationBlockEntities = new Object2ObjectOpenHashMap<>();
+    public static int REGISTERED_BLOCK_ENTITIES = 0;
+    public static int REGISTERED_DECORATIONS = 0;
 
     public static void register(InputStream inputStream) throws IOException {
         register(Json.GSON.fromJson(new InputStreamReader(inputStream, StandardCharsets.UTF_8), DecorationData.class));
@@ -70,7 +68,7 @@ public class DecorationRegistry {
         }
 
         decorationBlocks.put(data.id(), block);
-        BlockRegistry.registerBlock(data.id(), block);
+        BlockRegistry.registerBlock(data.name(), data.id(), block);
 
         Item.Properties properties = data.properties().toItemProperties();
 
@@ -130,7 +128,7 @@ public class DecorationRegistry {
                     DecorationData data = Json.GSON.fromJson(reader, DecorationData.class);
                     DecorationRegistry.register(data);
                 } catch (IOException | IllegalStateException e) {
-                    Filament.LOGGER.error("Failed to load decoration resource \"" + entry.getKey() + "\".");
+                    Filament.LOGGER.error("Failed to load decoration resource \"{}\".", entry.getKey());
                 }
             }
         }

--- a/src/main/java/de/tomalbrc/filament/registry/ItemRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/ItemRegistry.java
@@ -48,8 +48,8 @@ public class ItemRegistry {
 
         registerItem(data.id(), item, data.itemGroup() != null ? data.itemGroup() : Constants.ITEM_GROUP_ID);
 
-        if (data.name() != null) {
-            itemNames.putIfAbsent(data.id(), data.name());
+        if (data.displayName() != null) {
+            itemNames.putIfAbsent(data.id(), data.displayName());
         }
 
         REGISTERED_ITEMS++;

--- a/src/main/java/de/tomalbrc/filament/registry/ItemRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/ItemRegistry.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ItemRegistry {
-    private static final Map<ResourceLocation, String> itemNames = new HashMap<>();
+    private static final Map<ResourceLocation, Map<String, String>> itemNames = new HashMap<>();
     public static int REGISTERED_ITEMS = 0;
 
     public static void register(InputStream inputStream) throws IOException {

--- a/src/main/java/de/tomalbrc/filament/registry/ItemRegistry.java
+++ b/src/main/java/de/tomalbrc/filament/registry/ItemRegistry.java
@@ -6,6 +6,8 @@ import de.tomalbrc.filament.data.ItemData;
 import de.tomalbrc.filament.item.SimpleItem;
 import de.tomalbrc.filament.util.Constants;
 import de.tomalbrc.filament.util.Json;
+import de.tomalbrc.filament.util.Util;
+import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 import net.minecraft.core.Registry;
 import net.minecraft.core.component.TypedDataComponent;
@@ -19,9 +21,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ItemRegistry {
+    private static final Map<ResourceLocation, String> itemNames = new HashMap<>();
     public static int REGISTERED_ITEMS = 0;
 
     public static void register(InputStream inputStream) throws IOException {
@@ -41,7 +46,12 @@ public class ItemRegistry {
 
         BehaviourUtil.postInitItem(item, item, data.behaviourConfig());
 
-        ItemRegistry.registerItem(data.id(), item, data.itemGroup() != null ? data.itemGroup() : Constants.ITEM_GROUP_ID);
+        registerItem(data.id(), item, data.itemGroup() != null ? data.itemGroup() : Constants.ITEM_GROUP_ID);
+
+        if (data.name() != null) {
+            itemNames.putIfAbsent(data.id(), data.name());
+        }
+
         REGISTERED_ITEMS++;
     }
 
@@ -66,15 +76,14 @@ public class ItemRegistry {
                     ItemData data = Json.GSON.fromJson(reader, ItemData.class);
                     ItemRegistry.register(data);
                 } catch (IOException | IllegalStateException e) {
-                    Filament.LOGGER.error("Failed to load item resource \"" + entry.getKey() + "\".");
+                    Filament.LOGGER.error("Failed to load item resource \"{}\".", entry.getKey(), e);
                 }
             }
-
+            PolymerResourcePackUtils.RESOURCE_PACK_AFTER_INITIAL_CREATION_EVENT.register(builder -> Util.langGenerator(builder, "item", itemNames));
             if (!printedInfo) {
-                Filament.LOGGER.info("filament items registered: " + ItemRegistry.REGISTERED_ITEMS);
-                Filament.LOGGER.info("filament blocks registered: " + BlockRegistry.REGISTERED_BLOCKS);
-                Filament.LOGGER.info("filament decorations registered: " + DecorationRegistry.REGISTERED_DECORATIONS);
-                Filament.LOGGER.info("filament decoration block entities registered: " + DecorationRegistry.REGISTERED_BLOCK_ENTITIES);
+                for (String s : Arrays.asList("Filament items registered: " + REGISTERED_ITEMS, "Filament blocks registered: " + BlockRegistry.REGISTERED_BLOCKS, "Filament decorations registered: " + DecorationRegistry.REGISTERED_DECORATIONS, "Filament decoration block entities registered: " + DecorationRegistry.REGISTERED_BLOCK_ENTITIES)) {
+                    Filament.LOGGER.info(s);
+                }
                 printedInfo = true;
             }
         }

--- a/src/main/java/de/tomalbrc/filament/util/Util.java
+++ b/src/main/java/de/tomalbrc/filament/util/Util.java
@@ -4,6 +4,7 @@ import com.mojang.math.Axis;
 import de.tomalbrc.filament.Filament;
 import de.tomalbrc.filament.data.DecorationData;
 import de.tomalbrc.filament.decoration.block.entity.DecorationBlockEntity;
+import eu.pb4.polymer.resourcepack.api.ResourcePackBuilder;
 import eu.pb4.polymer.virtualentity.api.elements.InteractionElement;
 import eu.pb4.polymer.virtualentity.api.elements.ItemDisplayElement;
 import eu.pb4.polymer.virtualentity.api.elements.VirtualElement;
@@ -16,6 +17,7 @@ import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -39,7 +41,10 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Math;
 import org.joml.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -213,7 +218,7 @@ public class Util {
         if (direction == Direction.DOWN || direction == Direction.UP) {
             matrix4f.setTranslation(0, -0.5f, 0);
 
-            float ang = (float) java.lang.Math.toRadians(rotation+180);
+            float ang = (float) java.lang.Math.toRadians(rotation + 180);
             double angleRadians = Mth.atan2(-Mth.sin(ang), Mth.cos(ang));
             matrix4f.rotate(Axis.YP.rotation((float) angleRadians).normalize());
             matrix4f.rotate(Axis.XP.rotationDegrees(-90));
@@ -229,7 +234,7 @@ public class Util {
 
         }
 
-        itemDisplayElement.setDisplayWidth(size.x*2.f);
+        itemDisplayElement.setDisplayWidth(size.x * 2.f);
 
         itemDisplayElement.setTransformation(matrix4f);
         itemDisplayElement.setModelTransformation(data.properties().display);
@@ -252,10 +257,10 @@ public class Util {
     }
 
     public static void loadDatapackContents(ResourceManager resourceManager) {
-        ((RegistryUnfreezer)BuiltInRegistries.BLOCK).filament$unfreeze();
-        ((RegistryUnfreezer)BuiltInRegistries.ITEM).filament$unfreeze();
-        ((RegistryUnfreezer)BuiltInRegistries.BLOCK_ENTITY_TYPE).filament$unfreeze();
-        ((RegistryUnfreezer)BuiltInRegistries.CREATIVE_MODE_TAB).filament$unfreeze();
+        ((RegistryUnfreezer) BuiltInRegistries.BLOCK).filament$unfreeze();
+        ((RegistryUnfreezer) BuiltInRegistries.ITEM).filament$unfreeze();
+        ((RegistryUnfreezer) BuiltInRegistries.BLOCK_ENTITY_TYPE).filament$unfreeze();
+        ((RegistryUnfreezer) BuiltInRegistries.CREATIVE_MODE_TAB).filament$unfreeze();
 
         for (SimpleSynchronousResourceReloadListener listener : FilamentReloadUtil.getReloadListeners()) {
             listener.onResourceManagerReload(resourceManager);
@@ -271,5 +276,17 @@ public class Util {
             itemStack.shrink(1);
             livingEntity.onEquippedItemBroken(item, slot);
         }
+    }
+
+    public static void langGenerator(ResourcePackBuilder builder, String type, Map<ResourceLocation, String> names) {
+        String langPath = "assets/minecraft/lang/en_us.json";
+        Map<String, String> langEntries = new HashMap<>();
+        for (Map.Entry<ResourceLocation, String> entry : names.entrySet()) {
+            String key = type + "." + entry.getKey().getNamespace() + "." + entry.getKey().getPath();
+            langEntries.put(key, entry.getValue());
+        }
+
+        String jsonContent = Json.GSON.toJson(langEntries);
+        builder.addData(langPath, jsonContent.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/de/tomalbrc/filament/util/Util.java
+++ b/src/main/java/de/tomalbrc/filament/util/Util.java
@@ -278,15 +278,29 @@ public class Util {
         }
     }
 
-    public static void langGenerator(ResourcePackBuilder builder, String type, Map<ResourceLocation, String> names) {
-        String langPath = "assets/minecraft/lang/en_us.json";
-        Map<String, String> langEntries = new HashMap<>();
-        for (Map.Entry<ResourceLocation, String> entry : names.entrySet()) {
-            String key = type + "." + entry.getKey().getNamespace() + "." + entry.getKey().getPath();
-            langEntries.put(key, entry.getValue());
-        }
+    public static void langGenerator(ResourcePackBuilder builder, String type, Map<ResourceLocation, Map<String, String>> names) {
+        Map<String, Map<String, String>> langEntries = new HashMap<>();
 
-        String jsonContent = Json.GSON.toJson(langEntries);
-        builder.addData(langPath, jsonContent.getBytes(StandardCharsets.UTF_8));
+        for (Map.Entry<ResourceLocation, Map<String, String>> entry : names.entrySet()) {
+            ResourceLocation id = entry.getKey();
+            Map<String, String> nameMap = entry.getValue();
+
+            for (Map.Entry<String, String> langEntry : nameMap.entrySet()) {
+                String lang = langEntry.getKey();
+                String name = langEntry.getValue();
+                if (name != null) {
+                    String key = type + "." + id.getNamespace() + "." + id.getPath();
+                    langEntries
+                            .computeIfAbsent(lang, k -> new HashMap<>())
+                            .put(key, name);
+                }
+            }
+        }
+        for (Map.Entry<String, Map<String, String>> langFileEntry : langEntries.entrySet()) {
+            String lang = langFileEntry.getKey();
+            String langPath = "assets/" + Constants.MOD_ID + "/lang/" + lang + ".json";
+            String jsonContent = Json.GSON.toJson(langFileEntry.getValue());
+            builder.addData(langPath, jsonContent.getBytes(StandardCharsets.UTF_8));
+        }
     }
 }

--- a/src/main/java/de/tomalbrc/filament/util/Util.java
+++ b/src/main/java/de/tomalbrc/filament/util/Util.java
@@ -279,7 +279,7 @@ public class Util {
     }
 
     public static void langGenerator(ResourcePackBuilder builder, String type, Map<ResourceLocation, Map<String, String>> names) {
-        Map<String, Map<String, String>> langEntries = new HashMap<>();
+        Map<String, Map<String, Map<String, String>>> langEntries = new HashMap<>();
 
         for (Map.Entry<ResourceLocation, Map<String, String>> entry : names.entrySet()) {
             ResourceLocation id = entry.getKey();
@@ -291,16 +291,20 @@ public class Util {
                 if (name != null) {
                     String key = type + "." + id.getNamespace() + "." + id.getPath();
                     langEntries
+                            .computeIfAbsent(id.getNamespace(), k -> new HashMap<>())
                             .computeIfAbsent(lang, k -> new HashMap<>())
                             .put(key, name);
                 }
             }
         }
-        for (Map.Entry<String, Map<String, String>> langFileEntry : langEntries.entrySet()) {
-            String lang = langFileEntry.getKey();
-            String langPath = "assets/" + Constants.MOD_ID + "/lang/" + lang + ".json";
-            String jsonContent = Json.GSON.toJson(langFileEntry.getValue());
-            builder.addData(langPath, jsonContent.getBytes(StandardCharsets.UTF_8));
+        for (Map.Entry<String, Map<String, Map<String, String>>> namespaceEntry : langEntries.entrySet()) {
+            String namespace = namespaceEntry.getKey();
+            for (Map.Entry<String, Map<String, String>> langFileEntry : namespaceEntry.getValue().entrySet()) {
+                String lang = langFileEntry.getKey();
+                String langPath = "assets/" + namespace + "/lang/" + lang + ".json";
+                String jsonContent = Json.GSON.toJson(langFileEntry.getValue());
+                builder.addData(langPath, jsonContent.getBytes(StandardCharsets.UTF_8));
+            }
         }
     }
 }


### PR DESCRIPTION
### allows to add names for custom items, blocks, decoration!
**example:**
```
{
  "id": "minecraft:handsome_paper",
  "displayName": {
  "en_us": "§6Handsome Paper",
  "es_es": "§6Papel Hermoso",
  "fr_fr": "§6Beau Papier",
  }
  "vanillaItem": "minecraft:paper",
}

```

_name value is nullable._